### PR TITLE
New sketch page layout and previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 
 # production
 /build
-/public/sketches
+/src/.temp
 
 # misc
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -4887,6 +4887,55 @@
         }
       }
     },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
+      "integrity": "sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.1",
+        "nopt": "^5.0.0",
+        "npmlog": "^4.1.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.4",
+        "tar": "^6.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@next/env": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.4.tgz",
@@ -7339,12 +7388,12 @@
       "dev": true
     },
     "canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.7.0.tgz",
-      "integrity": "sha512-pzCxtkHb+5su5MQjTtepMDlIOtaXo277x0C0u3nMOxtkhTyQ+h2yNKhlROAaDllWgRyePAUitC08sXw26Eb6aw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
+      "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
       "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.14.0",
-        "node-pre-gyp": "^0.15.0",
         "simple-get": "^3.0.3"
       },
       "dependencies": {
@@ -8316,7 +8365,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -10212,11 +10262,11 @@
       "optional": true
     },
     "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "requires": {
-        "minipass": "^2.6.0"
+        "minipass": "^3.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -10901,14 +10951,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -11012,7 +11054,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true
     },
     "internal-ip": {
       "version": "4.3.0",
@@ -14780,27 +14823,20 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-        }
+        "yallist": "^4.0.0"
       }
     },
     "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "requires": {
-        "minipass": "^2.9.0"
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
       }
     },
     "mississippi": {
@@ -14940,26 +14976,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-    },
-    "needle": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
-      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -15913,30 +15929,6 @@
         }
       }
     },
-    "node-pre-gyp": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
-      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.3",
-        "needle": "^2.5.0",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4.4.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "node-releases": {
       "version": "1.1.70",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
@@ -15950,12 +15942,11 @@
       "optional": true
     },
     "nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "1"
       }
     },
     "normalize-html-whitespace": {
@@ -15987,29 +15978,6 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
         "remove-trailing-separator": "^1.0.1"
-      }
-    },
-    "npm-bundled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
-      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
-      "requires": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-    },
-    "npm-packlist": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1",
-        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -16250,25 +16218,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -17222,6 +17171,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -17232,7 +17182,8 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "optional": true
         }
       }
     },
@@ -18047,11 +17998,6 @@
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -19237,23 +19183,27 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
       "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5708,6 +5708,11 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5882,7 +5887,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -5892,7 +5896,6 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -5907,7 +5910,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -7336,6 +7338,28 @@
       "integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
       "dev": true
     },
+    "canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.7.0.tgz",
+      "integrity": "sha512-pzCxtkHb+5su5MQjTtepMDlIOtaXo277x0C0u3nMOxtkhTyQ+h2yNKhlROAaDllWgRyePAUitC08sXw26Eb6aw==",
+      "requires": {
+        "nan": "^2.14.0",
+        "node-pre-gyp": "^0.15.0",
+        "simple-get": "^3.0.3"
+      },
+      "dependencies": {
+        "simple-get": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "requires": {
+            "decompress-response": "^4.2.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        }
+      }
+    },
     "canvas2svg": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/canvas2svg/-/canvas2svg-1.0.16.tgz",
@@ -7578,8 +7602,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "optional": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -7764,8 +7787,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constantinople": {
       "version": "3.1.2",
@@ -8273,7 +8295,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "optional": true,
       "requires": {
         "mimic-response": "^2.0.0"
       }
@@ -8295,8 +8316,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -8434,8 +8454,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
@@ -8460,8 +8479,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -10193,6 +10211,14 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "optional": true
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -10253,7 +10279,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -10268,14 +10293,12 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10284,7 +10307,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10295,7 +10317,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10498,8 +10519,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "optional": true
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -10881,6 +10901,14 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -10984,8 +11012,7 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "optional": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "internal-ip": {
       "version": "4.3.0",
@@ -14727,8 +14754,7 @@
     "mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "optional": true
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -14752,6 +14778,30 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -14840,8 +14890,7 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanoid": {
       "version": "3.1.20",
@@ -14891,6 +14940,26 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "needle": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -15844,6 +15913,30 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "node-releases": {
       "version": "1.1.70",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
@@ -15855,6 +15948,15 @@
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
       "optional": true
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
     },
     "normalize-html-whitespace": {
       "version": "1.0.0",
@@ -15887,6 +15989,29 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-bundled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -15906,7 +16031,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -15926,8 +16050,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "optional": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -16127,6 +16250,25 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -17080,7 +17222,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -17091,8 +17232,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "optional": true
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -17908,6 +18048,11 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -18256,8 +18401,7 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "optional": true
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
       "version": "4.0.0",
@@ -19091,6 +19235,27 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
     },
     "tar-fs": {
       "version": "2.1.1",
@@ -20651,7 +20816,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       },
@@ -20659,20 +20823,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "optional": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "optional": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "optional": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -20682,7 +20843,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8317,6 +8317,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
+      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "babel-eslint": "10.1.0",
-    "canvas": "^2.7.0",
+    "canvas": "^2.8.0",
     "canvas2svg": "^1.0.16",
     "chroma-js": "^2.1.0",
     "delaunator": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
     "type-check": "tsc --noEmit",
-    "vercel-build": "yum install libuuid-devel libmount-devel zlib-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && npm run build"
+    "vercel-build": "yum install libuuid-devel libmount-devel zlib-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && mkdir -p src/.temp/sketches && npm run sync:sketches && npm run build",
+    "sync:sketches": "cp -r sketches/ src/.temp"
   },
   "engines": {
     "node": "12.x"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "canvas": "^2.8.0",
     "canvas2svg": "^1.0.16",
     "chroma-js": "^2.1.0",
+    "dayjs": "^1.10.5",
     "delaunator": "^4.0.1",
     "eslint": "^7.16.0",
     "eslint-config-prettier": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "vercel-build": "yum install libuuid-devel libmount-devel zlib-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && npm run build"
   },
   "engines": {
-    "node": "14.15.x"
+    "node": "12.x"
   },
   "dependencies": {
     "@types/chroma-js": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "type-check": "tsc --noEmit",
     "vercel-build": "yum install libuuid-devel libmount-devel zlib-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && mkdir -p src/.temp/sketches && npm run sync:sketches && npm run build",
-    "sync:sketches": "cp -r sketches/ src/.temp"
+    "sync:sketches": "cp -r sketches src/.temp/"
   },
   "engines": {
     "node": "12.x"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "babel-eslint": "10.1.0",
+    "canvas": "^2.7.0",
     "canvas2svg": "^1.0.16",
     "chroma-js": "^2.1.0",
     "delaunator": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "vercel-build": "yum install libuuid-devel libmount-devel zlib-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && npm run build"
   },
   "engines": {
     "node": "14.15.x"

--- a/sketches/001/README.md
+++ b/sketches/001/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['rsj', 'gbc', 'ptu', 'hnw']
 accentColor: '#E45566'
 
 pieces: 196
+timeToSolve: 36:11
 ---
 
 # 001

--- a/sketches/002/README.md
+++ b/sketches/002/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['hsj', 'usg', 'zlg', 'nnh']
 accentColor: '#00C2FF'
 
 pieces: 196
+timeToSolve: 33:23
 ---
 
 # 002

--- a/sketches/003/README.md
+++ b/sketches/003/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['aum', 'wln', 'bqg', 'sac']
 accentColor: '#8C2CFF'
 
 pieces: 400
+timeToSolve: 3:09:40
 ---
 
 # 003

--- a/sketches/004/README.md
+++ b/sketches/004/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['rpv', 'wzk', 'yiv', 'phv']
 accentColor: '#E745BD'
 
 pieces: 225
+timeToSolve: 1:30:20
 ---
 
 # 004

--- a/sketches/005/README.md
+++ b/sketches/005/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['tol', 'zop', 'ovo', 'qfo']
 accentColor: '#00A7FD'
 
 pieces: 225
+timeToSolve: 1:14:10
 ---
 
 # 005

--- a/sketches/006/README.md
+++ b/sketches/006/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['gtx', 'xat', 'eoh', 'que']
 accentColor: '#CE24FD'
 
 pieces: 225
+timeToSolve: 1:02:50
 ---
 
 # 006

--- a/sketches/007/README.md
+++ b/sketches/007/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['xpl', 'gbj', 'bqy', 'ebu']
 accentColor: '#EE6441'
 
 pieces: 225
+timeToSolve: 54:35
 ---
 
 # 007

--- a/sketches/008/README.md
+++ b/sketches/008/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['qps', 'jrl', 'yww', 'wji']
 accentColor: '#682AFF'
 
 pieces: 225
+timeToSolve: 48:05
 ---
 
 # 008

--- a/sketches/009/README.md
+++ b/sketches/009/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['uav', 'efp', 'cka', 'xja']
 accentColor: '#283DFF'
 
 pieces: 225
+timeToSolve: 47:20
 ---
 
 # 009

--- a/sketches/010/README.md
+++ b/sketches/010/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['yzh', 'tuy', 'zot', 'dfn']
 accentColor: '#D72BF7'
 
 pieces: 144
+timeToSolve: 25:00
 ---
 
 # 010

--- a/sketches/011/README.md
+++ b/sketches/011/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['zlq', 'mpj', 'hck', 'swd']
 accentColor: '#AA01FE'
 
 pieces: 196
+timeToSolve: 1:14:40
 ---
 
 # 011

--- a/sketches/012/README.md
+++ b/sketches/012/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['qng', 'nzp', 'sgs', 'hvn']
 accentColor: '#01CEFF'
 
 pieces: 225
+timeToSolve: 1:28:40
 ---
 
 # 012

--- a/sketches/013/README.md
+++ b/sketches/013/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['grw', 'guj', 'xfx', 'yqv']
 accentColor: '#000EDF'
 
 pieces: 324
+timeToSolve: 3:42:00
 ---
 
 # 013

--- a/sketches/014/README.md
+++ b/sketches/014/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['zgf', 'kbo', 'rwn', 'sxo']
 accentColor: '#E02FE0'
 
 pieces: 225
+timeToSolve: 1:57:18
 ---
 
 # 014

--- a/sketches/015/README.md
+++ b/sketches/015/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['ubp', 'vxr', 'svd', 'ncj']
 accentColor: '#EE8BFB'
 
 pieces: 169
+timeToSolve: 1:42:40
 ---
 
 # 015

--- a/sketches/016/README.md
+++ b/sketches/016/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['quv', 'sjw', 'wmk', 'fbo']
 accentColor: '#03DDE0'
 
 pieces: 289
+timeToSolve: 2:17:10
 ---
 
 # 016

--- a/sketches/017/README.md
+++ b/sketches/017/README.md
@@ -7,12 +7,13 @@ cutNoiseSeeds: ['prm', 'vxo', 'jlb', 'vue']
 accentColor: '#9E23FB'
 
 pieces: 225
+timeToSolve: 56:32
 ---
 
 # 017
 
 ![canvas](https://res.cloudinary.com/abstract-puzzles/image/upload/w_2000/017_zao-ozs-qlq-osa_prm-vxo-jlb-vue?raw=true)
 
-In this design the strokes expand to fill the empty space, creating eerie, almost biological forms. This inverts the colours of 016 with a luminous light-on-dark pallette.
+In this design the strokes expand to fill the empty space, creating eerie, almost biological forms. This inverts the colours of 016 with a luminous light-on-dark palette.
 
 I found it fun to match the more-isolated groups of colour together before connecting all the edge pieces of the puzzle and work outwards from there.

--- a/sketches/017/design/index.ts
+++ b/sketches/017/design/index.ts
@@ -23,7 +23,14 @@ export enum Seeds {
   Color,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -81,9 +88,7 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
   c.save()
 
   layers.forEach(({ color, composite, opacity }, layerI) => {
-    const layerCanvas = document.createElement('canvas')
-    layerCanvas.width = c.canvas.width
-    layerCanvas.height = c.canvas.height
+    const layerCanvas = createCanvas(c.canvas.width, c.canvas.height)
     const layerC = layerCanvas.getContext('2d') as CanvasRenderingContext2D
     layerC.setTransform(c.getTransform())
 

--- a/sketches/018/README.md
+++ b/sketches/018/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['fdn', 'bay', 'xlt', 'ire']
 accentColor: '#dd4583'
 
 pieces: 256
+timeToSolve: 1:21:50
 ---
 
 # 018

--- a/sketches/018/design/index.ts
+++ b/sketches/018/design/index.ts
@@ -22,7 +22,14 @@ export enum Seeds {
   Color,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -79,9 +86,7 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
   c.save()
 
   layers.forEach(({ color, composite, opacity }, layerI) => {
-    const layerCanvas = document.createElement('canvas')
-    layerCanvas.width = c.canvas.width
-    layerCanvas.height = c.canvas.height
+    const layerCanvas = createCanvas(c.canvas.width, c.canvas.height)
     const layerC = layerCanvas.getContext('2d') as CanvasRenderingContext2D
     layerC.setTransform(c.getTransform())
 

--- a/sketches/019/README.md
+++ b/sketches/019/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['gfq', 'ioy', 'jgv', 'gkb']
 accentColor: '#181fd1'
 
 pieces: 256
+timeToSolve: 1:04:45
 ---
 
 # 019

--- a/sketches/019/design/index.ts
+++ b/sketches/019/design/index.ts
@@ -21,7 +21,14 @@ export enum Seeds {
   Color,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -84,15 +91,11 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
   c.save()
   const transform = c.getTransform()
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
 
   layers.forEach(({ color, composite, opacity }, layerI) => {
-    const layerCanvas = document.createElement('canvas')
-    layerCanvas.width = c.canvas.width
-    layerCanvas.height = c.canvas.height
+    const layerCanvas = createCanvas(c.canvas.width, c.canvas.height)
     const layerC = layerCanvas.getContext('2d') as CanvasRenderingContext2D
     layerC.globalAlpha = SPINE_OPACITY
 

--- a/sketches/020/README.md
+++ b/sketches/020/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['ivl', 'rtu', 'yvc', 'ppm']
 accentColor: '#d5e371'
 
 pieces: 196
+timeToSolve: 30:42
 ---
 
 # 020

--- a/sketches/020/design/index.ts
+++ b/sketches/020/design/index.ts
@@ -24,7 +24,14 @@ export enum Seeds {
   Size,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -99,15 +106,11 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
   c.save()
   const transform = c.getTransform()
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
 
   layers.forEach(({ color, size, composite, opacity }, layerI) => {
-    const layerCanvas = document.createElement('canvas')
-    layerCanvas.width = c.canvas.width
-    layerCanvas.height = c.canvas.height
+    const layerCanvas = createCanvas(c.canvas.width, c.canvas.height)
     const layerC = layerCanvas.getContext('2d') as CanvasRenderingContext2D
     layerC.globalAlpha = STROKE_OPACITY
 

--- a/sketches/021/README.md
+++ b/sketches/021/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: ['wab', 'zdg', 'khr', 'cje']
 accentColor: '#FB1C98'
 
 pieces: 256
+timeToSolve: 1:34:15
 ---
 
 # 021

--- a/sketches/021/design/index.ts
+++ b/sketches/021/design/index.ts
@@ -25,7 +25,14 @@ export enum Seeds {
   Size,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -103,9 +110,7 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
 
   c.save()
   layers.forEach(({ color, size, composite, opacity }, layerI) => {
-    const layerCanvas = document.createElement('canvas')
-    layerCanvas.width = c.canvas.width
-    layerCanvas.height = c.canvas.height
+    const layerCanvas = createCanvas(c.canvas.width, c.canvas.height)
     const layerC = layerCanvas.getContext('2d') as CanvasRenderingContext2D
     layerC.setTransform(c.getTransform())
     layerC.globalAlpha = STROKE_OPACITY

--- a/sketches/022/README.md
+++ b/sketches/022/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [ete, yxl, vlv, ius]
 accentColor: '#f780c2'
 
 pieces: 225
+timeToSolve: 1:11:10
 ---
 
 # 022

--- a/sketches/022/design/index.ts
+++ b/sketches/022/design/index.ts
@@ -30,7 +30,14 @@ export enum Seeds {
   Bristle,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -103,17 +110,13 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
 
   c.save()
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
   tempC.setTransform(c.getTransform())
   tempC.globalAlpha = STROKE_OPACITY
 
   layers.forEach(({ hue, lightness, size, opacity }, layerI) => {
-    const layerCanvas = document.createElement('canvas')
-    layerCanvas.width = c.canvas.width
-    layerCanvas.height = c.canvas.height
+    const layerCanvas = createCanvas(c.canvas.width, c.canvas.height)
     const layerC = layerCanvas.getContext('2d') as CanvasRenderingContext2D
     layerC.setTransform(c.getTransform())
     layerC.globalAlpha = STROKE_OPACITY

--- a/sketches/023/README.md
+++ b/sketches/023/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [ins, syq, xeq, kca]
 accentColor: '#32bbef'
 
 pieces: 225
+timeToSolve: 1:20:30
 ---
 
 # 023

--- a/sketches/023/design/index.ts
+++ b/sketches/023/design/index.ts
@@ -31,7 +31,14 @@ export enum Seeds {
   Bristle,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -91,9 +98,7 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
 
   c.save()
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
   tempC.setTransform(c.getTransform())
   tempC.globalAlpha = STROKE_OPACITY

--- a/sketches/024/README.md
+++ b/sketches/024/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [akk, zbx, sms, frz]
 accentColor: '#ad2de2'
 
 pieces: 225
+timeToSolve: 1:26:10
 ---
 
 # 024

--- a/sketches/024/design/index.ts
+++ b/sketches/024/design/index.ts
@@ -33,7 +33,14 @@ export enum Seeds {
   Bristle,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layerHues = arrayValuesFromSimplex(
     HUES,
     simplex[Seeds.Color],
@@ -95,9 +102,7 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
 
   c.save()
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
   tempC.setTransform(c.getTransform())
   tempC.globalAlpha = STROKE_OPACITY

--- a/sketches/025/README.md
+++ b/sketches/025/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [zla, xqt, tvh, xcg]
 accentColor: '#e816b5'
 
 pieces: 144
+timeToSolve: 49:06
 ---
 
 # 025

--- a/sketches/025/design/index.ts
+++ b/sketches/025/design/index.ts
@@ -32,7 +32,14 @@ export enum Seeds {
   Bristle,
 }
 
-export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
+export const design = ({
+  c,
+  createCanvas,
+  simplex,
+  width,
+  height,
+  noiseStart,
+}: Design) => {
   const layers = Array.from(Array(LAYER_COUNT)).map((_, i) => {
     const hue = map(
       randomFromNoise(simplex[Seeds.Color].noise2D(10 + i * 23.1, 14.3)),
@@ -93,9 +100,7 @@ export const design = ({ c, simplex, width, height, noiseStart }: Design) => {
 
   c.save()
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
   tempC.setTransform(c.getTransform())
   tempC.globalAlpha = STROKE_OPACITY

--- a/sketches/026/README.md
+++ b/sketches/026/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [qtj, fvs, rxj, itc]
 accentColor: '#27C87A'
 
 pieces: 176
+timeToSolve: 47:20
 ---
 
 # 026

--- a/sketches/027/README.md
+++ b/sketches/027/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [ekg, ymi, bat, oyf]
 accentColor: '#50B4CC'
 
 pieces: 260
+timeToSolve: 1:20:15
 ---
 
 # 027

--- a/sketches/027/design/index.ts
+++ b/sketches/027/design/index.ts
@@ -129,6 +129,7 @@ const drawShape = (args: Shape) => {
 
 export const design = ({
   c,
+  createCanvas,
   simplex,
   width,
   height,
@@ -210,9 +211,7 @@ export const design = ({
   c.globalCompositeOperation = 'screen'
   c.globalAlpha = LINE_OPACITY
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
   tempC.setTransform(c.getTransform())
 

--- a/sketches/028/README.md
+++ b/sketches/028/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [bwy, ttq, irx, psd]
 accentColor: '#D5D458'
 
 pieces: 176
+timeToSolve: 48:54
 ---
 
 # 028

--- a/sketches/028/design/index.ts
+++ b/sketches/028/design/index.ts
@@ -127,6 +127,7 @@ const drawShape = (args: Shape) => {
 
 export const design = ({
   c,
+  createCanvas,
   simplex,
   width,
   height,
@@ -230,9 +231,7 @@ export const design = ({
   c.globalCompositeOperation = 'multiply'
   c.globalAlpha = LINE_OPACITY
 
-  const tempCanvas = document.createElement('canvas')
-  tempCanvas.width = c.canvas.width
-  tempCanvas.height = c.canvas.height
+  const tempCanvas = createCanvas(c.canvas.width, c.canvas.height)
   const tempC = tempCanvas.getContext('2d') as CanvasRenderingContext2D
   tempC.setTransform(c.getTransform())
 

--- a/sketches/029/README.md
+++ b/sketches/029/README.md
@@ -7,6 +7,7 @@ cutNoiseSeeds: [ojd, ihc, mwh, zmq]
 accentColor: '#FC5744'
 
 pieces: 260
+timeToSolve: 1:05:28
 ---
 
 # 029

--- a/src/components/AppSidebar/Controls/Input.tsx
+++ b/src/components/AppSidebar/Controls/Input.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components'
-import RefreshButton from './RefreshButton'
+
 import { Layer } from 'types'
 import { updateSeed } from 'store/actions'
 import { SketchContext } from 'store/Provider'
+import { ShuffleButton } from 'components/ShuffleButton'
 
 const StyledWrapper = styled.label`
   display: flex;
@@ -85,7 +86,7 @@ const Input: React.FC<Props> = ({
       />
 
       <RefreshWrapper>
-        <RefreshButton
+        <ShuffleButton
           onClick={() => {
             dispatch(updateSeed(layer, index))
             if (onChange) onChange()

--- a/src/components/AppSidebar/Controls/index.tsx
+++ b/src/components/AppSidebar/Controls/index.tsx
@@ -12,10 +12,10 @@ import {
 } from 'store/actions'
 import { Layer, ExportPart, ActionType } from 'types'
 import { trim } from 'styles/helpers'
+import { ShuffleButton } from 'components/ShuffleButton'
 
 import Input from './Input'
 import ExportButton from './ExportButton'
-import RefreshButton from './RefreshButton'
 import ToggleButton from './ToggleButton'
 import RangeSlider from './RangeSlider'
 import { BuyPrintsButton } from '../BuyPrintsButton'
@@ -88,7 +88,7 @@ const Controls = () => {
           <>
             <H3>
               Noise seed{designNoiseSeeds.length > 1 && 's'}{' '}
-              <RefreshButton
+              <ShuffleButton
                 onClick={() => {
                   dispatch(updateSeed(Layer.Design))
                   trackEvent('Update design seed', {
@@ -158,7 +158,7 @@ const Controls = () => {
           <>
             <H3>
               Noise seed{cutNoiseSeeds.length > 1 && 's'}{' '}
-              <RefreshButton
+              <ShuffleButton
                 onClick={() => {
                   dispatch(updateSeed(Layer.Cut))
                   trackEvent('Update cut seed', { id: sketch?.id, all: true })

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 
-const StyledButton = styled.a`
+const StyledButton = styled.a<{
+  disabled?: boolean
+}>`
   position: relative;
   display: flex;
   flex: 1 0 10em;
@@ -29,6 +31,12 @@ const StyledButton = styled.a`
   &:active {
     box-shadow: 0 0 0 0 rgba(var(--color-accent), 0.3);
   }
+
+  ${({ disabled }) => disabled && `
+    pointer-events: none;
+    --color-accent: 200, 200, 200;
+    opacity: 0.5;
+  `}
 `
 
 export const Button = StyledButton

--- a/src/components/CloudinaryImage/index.tsx
+++ b/src/components/CloudinaryImage/index.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 
+import { ResponsiveImage } from 'components/ResponsiveImage'
+
 export const CLOUDINARY_URL =
   'https://res.cloudinary.com/abstract-puzzles/image/upload'
 
@@ -17,92 +19,35 @@ export const buildCloudinaryImageUrl = (
   return `${CLOUDINARY_URL}/${params.join(',')}/${path}`
 }
 
-const StyledWrapper = styled.figure<{ $hasAspectRatio: boolean }>`
-  background: black;
-  ${({ $hasAspectRatio }) =>
-    $hasAspectRatio &&
-    `
-      margin: 0;
-      width: 100%;
-      height: 0;
-      overflow: hidden;
-  `}
-`
-
-const StyledImage = styled.img<{ $hasLoaded: boolean }>`
-  width: 100%;
-  opacity: ${({ $hasLoaded }) => ($hasLoaded ? 1 : 0)};
-  transition: opacity 0.1s linear;
-`
-
 interface Props {
   imagePath: string
-  aspectRatio?: number
   options?: Record<string, string | number>
+  aspectRatio?: number
 }
 
 export const CloudinaryImage: React.FC<Props> = ({
   imagePath,
-  aspectRatio,
   options,
+  aspectRatio,
   ...props
-}) => {
-  const imageWrapperElement = useRef<HTMLDivElement>(null)
-  const imageElement = useRef<HTMLImageElement>(null)
-  const [imageWidth, setImageWidth] = useState(0)
-  const [hasLoaded, setHasLoaded] = useState(false)
-
-  const calculateWidth = () => {
-    const pixelRatio = window.devicePixelRatio || 1
-    const newWidth = imageWrapperElement?.current?.clientWidth
-
-    // don't resize if it's smaller than the current
-    if (!newWidth || newWidth * pixelRatio < imageWidth) return
-
-    // round up to the nearest 50
-    setImageWidth(Math.ceil((newWidth * pixelRatio) / 50) * 50)
-  }
-
-  useEffect(() => {
-    calculateWidth()
-
-    window.addEventListener('resize', calculateWidth)
-
-    return () => {
-      window.removeEventListener('resize', calculateWidth)
-    }
-  }, [])
-
-  const dimensions: Props['options'] = { w: imageWidth }
-  if (aspectRatio) {
-    dimensions.h = Math.round(imageWidth * aspectRatio)
-  }
-  const imageOptions = Object.assign({
-    c: 'fill'
-  }, dimensions, options || {})
-
-  return (
-    <StyledWrapper
-      ref={imageWrapperElement}
-      $hasAspectRatio={!!aspectRatio}
-      style={
-        aspectRatio
-          ? {
-              paddingBottom: `${Math.round(aspectRatio * 10000) / 100}%`,
-            }
-          : {}
+}) => (
+  <ResponsiveImage
+    formatPath={({ width }) => {
+      const dimensions: Props['options'] = { w: width }
+      if (aspectRatio) {
+        dimensions.h = Math.round(width * aspectRatio)
       }
-    >
-      {imageWidth !== 0 && (
-        <StyledImage
-          ref={imageElement}
-          src={buildCloudinaryImageUrl(imagePath, imageOptions)}
-          key={imagePath}
-          $hasLoaded={hasLoaded}
-          onLoad={() => setHasLoaded(true)}
-          {...props}
-        />
-      )}
-    </StyledWrapper>
-  )
-}
+      const imageOptions = Object.assign(
+        {
+          c: 'fill',
+        },
+        dimensions,
+        options || {}
+      )
+
+      return buildCloudinaryImageUrl(imagePath, imageOptions)
+    }}
+    aspectRatio={aspectRatio}
+    {...props}
+  />
+)

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,7 +5,7 @@ const StyledHeader = styled.header`
   margin: 2em auto 1em;
 
   @media (min-width: 500px) {
-    text-align: right;
+    text-align: center;
   }
 `
 
@@ -25,11 +25,11 @@ const StyledH1 = styled.h1`
   }
 `
 
-export const Header = () => (
+export const Header: React.FC = ({ children }) => (
   <StyledHeader>
     <StyledH1>
       <Link href="/">
-        <a>Abstract Puzzles</a>
+        <a>{children}</a>
       </Link>
     </StyledH1>
   </StyledHeader>

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -14,10 +14,12 @@ const StyledWrapper = styled.div`
 
 interface Props {
   accentColorRgb?: string
+  title?: string
 }
 
 export const PageWrapper: React.FC<Props> = ({
   accentColorRgb,
+  title,
   children,
 }) => {
   let faviconUrl = '/api/favicon.svg'
@@ -30,7 +32,9 @@ export const PageWrapper: React.FC<Props> = ({
       }
     >
       <Favicon accentColorRgb={accentColorRgb} />
-      <Header />
+      <Header>
+        {title || 'Abstract Puzzles'}
+      </Header>
 
       {children}
 

--- a/src/components/ResponsiveImage/index.tsx
+++ b/src/components/ResponsiveImage/index.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect, useRef } from 'react'
+import styled from 'styled-components'
+
+const StyledWrapper = styled.figure<{ $hasAspectRatio: boolean }>`
+  background: black;
+  ${({ $hasAspectRatio }) =>
+    $hasAspectRatio &&
+    `
+      margin: 0;
+      width: 100%;
+      height: 0;
+      overflow: hidden;
+  `}
+`
+
+const StyledImage = styled.img<{ $hasLoaded: boolean }>`
+  width: 100%;
+  opacity: ${({ $hasLoaded }) => ($hasLoaded ? 1 : 0)};
+  transition: opacity 0.1s linear;
+`
+
+interface Props {
+  formatPath: ({ width }: { width: number }) => string
+  aspectRatio?: number
+}
+
+export const ResponsiveImage: React.FC<Props> = ({
+  formatPath,
+  aspectRatio,
+  ...props
+}) => {
+  const imageWrapperElement = useRef<HTMLDivElement>(null)
+  const imageElement = useRef<HTMLImageElement>(null)
+  const [imageWidth, setImageWidth] = useState(0)
+  const [hasLoaded, setHasLoaded] = useState(false)
+
+  const calculateWidth = () => {
+    const pixelRatio = window.devicePixelRatio || 1
+    const newWidth = imageWrapperElement?.current?.clientWidth
+
+    // don't resize if it's smaller than the current
+    if (!newWidth || newWidth * pixelRatio < imageWidth) return
+
+    // round up to the nearest 50
+    setImageWidth(Math.ceil((newWidth * pixelRatio) / 50) * 50)
+  }
+
+  useEffect(() => {
+    calculateWidth()
+
+    window.addEventListener('resize', calculateWidth)
+
+    return () => {
+      window.removeEventListener('resize', calculateWidth)
+    }
+  }, [])
+
+  return (
+    <StyledWrapper
+      ref={imageWrapperElement}
+      $hasAspectRatio={!!aspectRatio}
+      style={
+        aspectRatio
+          ? {
+              paddingBottom: `${Math.round(aspectRatio * 10000) / 100}%`,
+            }
+          : {}
+      }
+    >
+      {imageWidth !== 0 && (
+        <StyledImage
+          ref={imageElement}
+          src={formatPath({ width: imageWidth })}
+          $hasLoaded={hasLoaded}
+          onLoad={() => setHasLoaded(true)}
+          {...props}
+        />
+      )}
+    </StyledWrapper>
+  )
+}

--- a/src/components/ResponsiveImage/index.tsx
+++ b/src/components/ResponsiveImage/index.tsx
@@ -11,7 +11,8 @@ export const spin = keyframes`
 `
 
 const StyledWrapper = styled.figure<{ $hasAspectRatio: boolean }>`
-  background: black;
+  background: #111;
+  color: rgba(255, 255, 255, 0.75);
   position: relative;
 
   ${({ $hasAspectRatio }) =>
@@ -37,12 +38,26 @@ const StyledLoader = styled.div<{ $visible: boolean }>`
   width: 2em;
   height: 2em;
   margin: -1em;
-  border: 0.125em solid rgba(255, 255, 255, 0.75);
+  border: 0.125em solid currentColor;
   border-top-color: transparent;
   border-radius: 50%;
   transition: opacity 0.2s linear;
   opacity: 0;
   animation: ${spin} 1s linear infinite;
+
+  ${({ $visible }) => $visible && `opacity: 1;`}
+`
+
+const StyledTimeout = styled.svg<{ $visible: boolean }>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2em;
+  height: 2em;
+  margin: -1em;
+  fill: currentColor;
+  transition: opacity 0.2s linear;
+  opacity: 0;
 
   ${({ $visible }) => $visible && `opacity: 1;`}
 `
@@ -61,15 +76,31 @@ export const ResponsiveImage: React.FC<Props> = ({
   const imageElement = useRef<HTMLImageElement>(null)
   const [imageWidth, setImageWidth] = useState(0)
   const [hasLoaded, setHasLoaded] = useState(false)
-  const [showLoader, setShowLoader] = useState(false)
   const loadedRef = useRef(hasLoaded)
   loadedRef.current = hasLoaded
 
+  const [showLoader, setShowLoader] = useState(false)
+  const loaderTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const [showTimeout, setShowTimeout] = useState(false)
+  const timeoutTimerRef = useRef<NodeJS.Timeout | null>(null)
+
   useEffect(() => {
     setHasLoaded(false)
-    setTimeout(() => {
+    setShowLoader(false)
+    setShowTimeout(false)
+    if (loaderTimerRef.current) clearTimeout(loaderTimerRef.current)
+    if (timeoutTimerRef.current) clearTimeout(timeoutTimerRef.current)
+
+    loaderTimerRef.current = setTimeout(() => {
       if (!loadedRef.current) setShowLoader(true)
     }, 500)
+    timeoutTimerRef.current = setTimeout(() => {
+      if (!loadedRef.current) {
+        setShowTimeout(true)
+        setShowLoader(false)
+      }
+    }, 10000)
   }, [formatPath])
 
   const calculateWidth = () => {
@@ -96,6 +127,7 @@ export const ResponsiveImage: React.FC<Props> = ({
   const onLoad = () => {
     setHasLoaded(true)
     setShowLoader(false)
+    setShowTimeout(false)
   }
 
   return (
@@ -111,6 +143,24 @@ export const ResponsiveImage: React.FC<Props> = ({
       }
     >
       <StyledLoader $visible={showLoader} aria-hidden />
+      <StyledTimeout
+        $visible={showTimeout}
+        aria-hidden
+        xmlns="http://www.w3.org/2000/svg"
+        x="0"
+        y="0"
+        viewBox="0 0 16 16"
+      >
+        {showTimeout && (
+          <title>
+            Oh no this image couldn’t load, click here to open in explorer
+            instead
+          </title>
+        )}
+        <circle cx="5" cy="6" r="1" />
+        <path d="M11 5c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zM11.53 12.18C11.49 12.07 10.47 9.5 8 9.5c-2.48 0-3.49 2.42-3.54 2.53l-.93-.38C3.59 11.52 4.84 8.5 8 8.5c3.17 0 4.42 3.19 4.47 3.32l-.94.36z" />
+        <circle cx="11" cy="6" r="1" />
+      </StyledTimeout>
       {imageWidth !== 0 && (
         <StyledImage
           ref={imageElement}

--- a/src/components/ResponsiveImage/index.tsx
+++ b/src/components/ResponsiveImage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import styled from 'styled-components'
 
 const StyledWrapper = styled.figure<{ $hasAspectRatio: boolean }>`
@@ -33,6 +33,10 @@ export const ResponsiveImage: React.FC<Props> = ({
   const imageElement = useRef<HTMLImageElement>(null)
   const [imageWidth, setImageWidth] = useState(0)
   const [hasLoaded, setHasLoaded] = useState(false)
+
+  useLayoutEffect(() => {
+    setHasLoaded(false)
+  }, [formatPath])
 
   const calculateWidth = () => {
     const pixelRatio = window.devicePixelRatio || 1

--- a/src/components/ResponsiveImage/index.tsx
+++ b/src/components/ResponsiveImage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import styled, { keyframes } from 'styled-components'
 
 export const spin = keyframes`
@@ -65,7 +65,7 @@ export const ResponsiveImage: React.FC<Props> = ({
   const loadedRef = useRef(hasLoaded)
   loadedRef.current = hasLoaded
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     setHasLoaded(false)
     setTimeout(() => {
       if (!loadedRef.current) setShowLoader(true)

--- a/src/components/ShuffleButton.tsx
+++ b/src/components/ShuffleButton.tsx
@@ -5,7 +5,7 @@ interface Props {
   onClick?: () => void
 }
 
-const StyledRefreshButton = styled.button`
+const StyledShuffleButton = styled.button`
   position: relative;
   outline: none;
   color: #777;
@@ -28,12 +28,10 @@ const StyledIcon = styled.svg`
   vertical-align: middle;
 `
 
-const RefreshButton: React.FC<Props> = ({ onClick }) => (
-  <StyledRefreshButton onClick={onClick}>
+export const ShuffleButton: React.FC<Props> = ({ onClick }) => (
+  <StyledShuffleButton onClick={onClick} title="Shuffle">
     <StyledIcon xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 125">
       <path d="M11.4 41.4a38.2 38.2 0 0 1 71.8-6.6H70v7.8h26.7V16.3h-7.9V28A46.7 46.7 0 0 0 3.4 40.8L3 42.4h8.1l.3-1zM88.9 57.6l-.3 1a38.2 38.2 0 0 1-71.8 6.6H30v-7.8H3.3v26.4h7.9V72a46.5 46.5 0 0 0 85.4-12.8l.4-1.6h-8.1z" />
     </StyledIcon>
-  </StyledRefreshButton>
+  </StyledShuffleButton>
 )
-
-export default RefreshButton

--- a/src/components/SketchCard/index.tsx
+++ b/src/components/SketchCard/index.tsx
@@ -26,10 +26,12 @@ export const SketchCard = ({
 }: SketchContent) => (
   <Link href={pageLink} passHref>
     <StyledLink style={{ '--color-accent': accentColorRgb } as object}>
-      <StyledTitle>{id}</StyledTitle>
+      {/* <StyledTitle>{id}</StyledTitle> */}
       <CloudinaryImage
-        imagePath={imagePath.solveEnd}
-        aspectRatio={1}
+        // imagePath={imagePath.solveEnd}
+        // aspectRatio={1}
+        imagePath={imagePath.solveMiddle}
+        aspectRatio={9/16}
       />
     </StyledLink>
   </Link>

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -1,29 +1,30 @@
 import React from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
+import ReactMarkdown from 'react-markdown'
 
 import { SketchContent } from 'types'
+import { Button } from 'components/Button'
 import { CloudinaryImage } from 'components/CloudinaryImage'
 import { SketchPreviewCard } from 'components/SketchPreviewCard'
+import { SketchVariant } from 'components/SketchVariant'
 
 import { Player } from './Player'
-import ReactMarkdown from 'react-markdown'
 
 const BREAKPOINT = '800px'
 
 const StyledGrid = styled.article`
   display: grid;
-  grid-template-columns: 1fr 2fr;
   grid-template-rows: auto 1fr;
-  grid-template-areas: 'video video' 'image details';
+  grid-template-columns: 2fr 3fr;
+  grid-template-areas: 'image preview' 'image details' 'video video';
   grid-gap: 2em;
   margin: 3em 0;
 
   @media (max-width: ${BREAKPOINT}) {
     margin: 2em 0;
-    grid-gap: 1.5em;
     grid-template-columns: 1fr;
-    grid-template-areas: 'image' 'details';
+    grid-template-areas: 'image' 'details' 'video' 'preview' 'mobile-nav';
   }
 
   > * > *:first-child {
@@ -48,22 +49,66 @@ const StyledVideo = styled.figure`
   height: 0;
   padding-bottom: 56.35%;
   background: #000;
+`
+
+const StyledSidebar = styled.div`
+  grid-area: image;
+
+  @media (min-width: ${BREAKPOINT}) {
+    margin: -2em 0;
+  }
+`
+
+const StyledSidebarInner = styled.figure`
+  top: 0;
+  bottom: 0;
+  margin: 0;
+
+  @media (min-width: ${BREAKPOINT}) {
+    position: sticky;
+    padding: 2em 0;
+    display: flex;
+    gap: 2em;
+    justify-content: space-between;
+    flex-direction: column;
+    max-height: 100vh;
+    height: 100%;
+  }
+`
+
+const StyledImageWrapper = styled.div`
+  flex: 1 0 0;
+`
+
+const StyledImageLink = styled.a`
+  display: block;
+  position: sticky;
+  top: 2em;
+  bottom: 0;
+  z-index: 1;
+`
+
+const StyledNav = styled.nav`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+
+  > * {
+    flex: 1 0 8em;
+  }
 
   @media (max-width: ${BREAKPOINT}) {
     display: none;
   }
 `
 
-const StyledImageWrapper = styled.div`
-  grid-area: image;
-`
+const StyledMobileNav = styled(StyledNav)`
+  grid-area: mobile-nav;
+  display: none;
 
-const StyledImage = styled.figure`
-  position: sticky;
-  top: 2em;
-  bottom: 0;
-  margin: 0;
-  text-align: center;
+  @media (max-width: ${BREAKPOINT}) {
+    display: flex;
+  }
 `
 
 const StyledDetails = styled.div`
@@ -99,6 +144,47 @@ const StyledLink = styled.a<{ $internal: boolean }>`
   `}
 `
 
+const StyledMeta = styled.aside`
+  font-style: italic;
+  margin-top: 1.5em;
+  font-size: 0.8em;
+`
+
+const StyledPreviews = styled.div`
+  grid-area: preview;
+`
+
+const StyledPreviewGrid = styled.section`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 1em;
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr 1fr;
+    > *:last-child {
+      display: none;
+    }
+  }
+`
+
+const StyledDivider = styled.hr`
+  display: none;
+  height: 0.2em;
+  width: 100%;
+  background: #ddd;
+  border: 0;
+  border-radius: 0.1em;
+`
+
+const StyledPreviewDescription = styled.div`
+  display: none;
+  margin: 1em 0 1.5em;
+
+  @media (min-width: ${BREAKPOINT}) {
+    font-size: 0.8em;
+  }
+`
+
 const LinkWrapper: React.FC<{ href: string }> = ({ children, href }) => (
   <Link href={href} passHref>
     <StyledLink $internal={href.startsWith('/')}>{children}</StyledLink>
@@ -106,7 +192,8 @@ const LinkWrapper: React.FC<{ href: string }> = ({ children, href }) => (
 )
 
 interface Props extends SketchContent {
-  previewSketches: SketchContent[]
+  prevSketchLink?: string
+  nextSketchLink?: string
 }
 
 export const SketchPage = ({
@@ -116,113 +203,83 @@ export const SketchPage = ({
   imagePath,
   markdownDescription,
   pieces,
-  datePublished,
   designNoiseSeeds,
   cutNoiseSeeds,
-}: Props) => (
-  <StyledGrid>
-    <StyledVideo>
-      <Player id={id} youTubeLink={youTubeLink} imagePath={imagePath} />
-    </StyledVideo>
+  nextSketchLink,
+  prevSketchLink,
+}: Props) => {
+  const navButtons = (
+    <>
+      <Link href={nextSketchLink || '/'} passHref>
+        <Button disabled={!nextSketchLink}>Newer</Button>
+      </Link>
+      <Link href={prevSketchLink || '/'} passHref>
+        <Button disabled={!prevSketchLink}>Older</Button>
+      </Link>
+    </>
+  )
 
-    <StyledImageWrapper>
-      <StyledImage>
-        <CloudinaryImage imagePath={imagePath.solveEnd} aspectRatio={1} />
-        <p style={{ marginTop: '1em' }}>
-          Posted {new Date(datePublished).toLocaleDateString('en-GB')}
-        </p>
-        <p>Solved 1h 43mins</p>
-        <p style={{ marginBottom: '0.5em' }}>{pieces} pieces</p>
-        <p>
-          <svg
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 15 15"
-            style={{ width: '1em', height: '1em', marginRight: '0.5em' }}
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M9.97 3.47a.75.75 0 011.06 0l3.75 3.75a.75.75 0 010 1.06l-3.75 3.75a.75.75 0 11-1.06-1.06l2.47-2.47H.75a.75.75 0 010-1.5h11.69L9.97 4.53a.75.75 0 010-1.06z"
-              fill="#000"
+  return (
+    <StyledGrid>
+      <StyledVideo>
+        <Player id={id} youTubeLink={youTubeLink} imagePath={imagePath} />
+      </StyledVideo>
+
+      <StyledSidebar>
+        <StyledSidebarInner>
+          <StyledImageWrapper>
+            <Link href={appLink} passHref>
+              <StyledImageLink>
+                <CloudinaryImage
+                  imagePath={imagePath.solveEnd}
+                  aspectRatio={1}
+                />
+              </StyledImageLink>
+            </Link>
+            <SketchVariant
+              designNoiseSeeds={designNoiseSeeds}
+              cutNoiseSeeds={cutNoiseSeeds}
             />
-          </svg>{' '}
-          Previous puzzle
-        </p>
-        <p>
-          <svg
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 15 15"
-            style={{
-              width: '1em',
-              height: '1em',
-              marginRight: '0.5em',
-              transform: 'rotate(180deg)',
-            }}
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M9.97 3.47a.75.75 0 011.06 0l3.75 3.75a.75.75 0 010 1.06l-3.75 3.75a.75.75 0 11-1.06-1.06l2.47-2.47H.75a.75.75 0 010-1.5h11.69L9.97 4.53a.75.75 0 010-1.06z"
-              fill="#000"
+          </StyledImageWrapper>
+
+          <StyledNav>{navButtons}</StyledNav>
+        </StyledSidebarInner>
+      </StyledSidebar>
+
+      <StyledMobileNav>{navButtons}</StyledMobileNav>
+
+      <StyledDetails>
+        <ReactMarkdown
+          // eslint-disable-next-line react/no-children-prop
+          children={markdownDescription}
+          disallowedTypes={['heading', 'image']}
+          renderers={{
+            link: LinkWrapper,
+          }}
+        />
+        <StyledMeta>{pieces} pieces &bull; Solved in 1h 43mins</StyledMeta>
+      </StyledDetails>
+
+      <StyledPreviews>
+        <StyledPreviewGrid>
+          {[...Array(3)].map((_, i) => (
+            <SketchPreviewCard
+              key={i}
+              id={id}
+              designNoiseSeeds={designNoiseSeeds}
+              cutNoiseSeeds={cutNoiseSeeds}
             />
-          </svg>{' '}
-          Next puzzle
-        </p>
-      </StyledImage>
-    </StyledImageWrapper>
+          ))}
+        </StyledPreviewGrid>
+        <StyledPreviewDescription>
+          Each jigsaw is designed and developed entirely in the browser. Above
+          are some random outputs generated on the fly just for you &ndash;
+          crack open <Link href={appLink}>the explorer</Link> for finer control
+          of the parameters.
+        </StyledPreviewDescription>
 
-    <StyledDetails>
-      <ReactMarkdown
-        // eslint-disable-next-line react/no-children-prop
-        children={markdownDescription}
-        disallowedTypes={['heading', 'image']}
-        renderers={{
-          link: LinkWrapper,
-        }}
-      />
-
-      <h2 style={{ fontSize: '1.5em', margin: '1em 0 0' }}>Explore designs</h2>
-      <p>
-        <small>
-          These designs have been generated on the fly from the code for this
-          jigsaw:
-        </small>
-      </p>
-
-      <section
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr',
-          gridGap: '1em',
-          margin: '0.5em 0',
-        }}
-      >
-        {[...Array(3)].map((_, i) => (
-          <SketchPreviewCard
-            key={i}
-            id={id}
-            designNoiseSeeds={designNoiseSeeds}
-            cutNoiseSeeds={cutNoiseSeeds}
-          />
-        ))}
-      </section>
-
-      <p>
-        You can play with the parameters of this programme in{' '}
-        <Link href={appLink} passHref>
-          <a>the explorer</a>
-        </Link>{' '}
-        or check the code out{' '}
-        <Link
-          href={`https://github.com/pouretrebelle/jigsaws/tree/master/sketches/${id}`}
-          passHref
-        >
-          <a>on GitHub</a>
-        </Link>
-        .
-      </p>
-    </StyledDetails>
-  </StyledGrid>
-)
+        <StyledDivider />
+      </StyledPreviews>
+    </StyledGrid>
+  )
+}

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -24,7 +24,7 @@ const StyledGrid = styled.article`
   @media (max-width: ${BREAKPOINT}) {
     margin: 2em 0;
     grid-template-columns: 1fr;
-    grid-template-areas: 'image' 'details' 'video' 'preview' 'mobile-nav';
+    grid-template-areas: 'image' 'details' 'video' 'mobile-nav';
   }
 
   > * > *:first-child {
@@ -152,19 +152,16 @@ const StyledMeta = styled.aside`
 
 const StyledPreviews = styled.div`
   grid-area: preview;
+
+  @media (max-width: ${BREAKPOINT}) {
+    display: none;
+  }
 `
 
 const StyledPreviewGrid = styled.section`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 1em;
-
-  @media (max-width: 600px) {
-    grid-template-columns: 1fr 1fr;
-    > *:last-child {
-      display: none;
-    }
-  }
 `
 
 const StyledDivider = styled.hr`
@@ -247,7 +244,12 @@ export const SketchPage = ({
         </StyledSidebarInner>
       </StyledSidebar>
 
-      <StyledMobileNav>{navButtons}</StyledMobileNav>
+      <StyledMobileNav>
+        <Link href={appLink} passHref>
+          <Button style={{ flexBasis: '100%' }}>Open in explorer</Button>
+        </Link>
+        {navButtons}
+      </StyledMobileNav>
 
       <StyledDetails>
         <ReactMarkdown

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -3,11 +3,9 @@ import styled, { css } from 'styled-components'
 import Link from 'next/link'
 
 import { SketchContent } from 'types'
-import { makeRandomSeedArray } from 'lib/seeds'
 import { CloudinaryImage } from 'components/CloudinaryImage'
-import { SketchCard } from 'components/SketchCard'
+import { SketchPreviewCard } from 'components/SketchPreviewCard'
 import { Button } from 'components/Button'
-import RefreshButton from 'components/AppSidebar/Controls/RefreshButton'
 
 import { Player } from './Player'
 import ReactMarkdown from 'react-markdown'
@@ -197,6 +195,8 @@ export const SketchPage = ({
   previewSketches,
   pieces,
   datePublished,
+  designNoiseSeeds,
+  cutNoiseSeeds,
 }: Props) => (
   <StyledGrid>
     {/* <StyledTitle>{id}</StyledTitle> */}
@@ -209,12 +209,9 @@ export const SketchPage = ({
       <StyledImage>
         <CloudinaryImage imagePath={imagePath.solveEnd} aspectRatio={1} />
         <p style={{ marginTop: '1em' }}>
-          Posted{' '}
-          {new Date(datePublished).toLocaleDateString('en-GB')}
+          Posted {new Date(datePublished).toLocaleDateString('en-GB')}
         </p>
-        <p>
-          Solved 1h 43mins
-          </p>
+        <p>Solved 1h 43mins</p>
         <p style={{ marginBottom: '0.5em' }}>{pieces} pieces</p>
         <p>
           <svg
@@ -297,16 +294,11 @@ export const SketchPage = ({
         }}
       >
         {[...Array(3)].map((_, i) => (
-          <article key={i}>
-            <CloudinaryImage
-              imagePath={`0${parseInt(id) - 1 - i}_solve_end.jpg`}
-              aspectRatio={1}
-            />
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <small>{makeRandomSeedArray(4).join('_')}</small>
-              <RefreshButton />
-            </div>
-          </article>
+          <SketchPreviewCard
+            key={i}
+            designNoiseSeeds={designNoiseSeeds}
+            cutNoiseSeeds={cutNoiseSeeds}
+          />
         ))}
       </section>
 

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import Link from 'next/link'
 
 import { SketchContent } from 'types'
 import { CloudinaryImage } from 'components/CloudinaryImage'
 import { SketchPreviewCard } from 'components/SketchPreviewCard'
-import { Button } from 'components/Button'
 
 import { Player } from './Player'
 import ReactMarkdown from 'react-markdown'
 
-const BP_MOBILE = '500px'
-const BP_DESKTOP = '900px'
+const BREAKPOINT = '800px'
 
 const StyledGrid = styled.article`
   display: grid;
@@ -21,25 +19,10 @@ const StyledGrid = styled.article`
   grid-gap: 2em;
   margin: 3em 0;
 
-  /* @media (max-width: ${BP_DESKTOP}) {
-    grid-template-columns: 1fr 2fr;
-    grid-template-rows: auto 1fr;
-    grid-template-areas: 'title image' 'actions image' 'empty details';
-  }
-
-  @media (max-width: ${BP_MOBILE}) {
+  @media (max-width: ${BREAKPOINT}) {
     margin: 2em 0;
     grid-gap: 1.5em;
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr auto auto;
-    grid-template-areas: 'title' 'image' 'actions' 'details' 'previews';
-  } */
-
-  @media (max-width: ${BP_MOBILE}) {
-    margin: 2em 0;
-    grid-gap: 1.5em;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr auto auto;
     grid-template-areas: 'image' 'details';
   }
 
@@ -56,19 +39,6 @@ const StyledGrid = styled.article`
   }
 `
 
-const StyledTitle = styled.h2`
-  grid-area: title;
-  align-self: end;
-  margin: 0;
-  font-size: 4em;
-  font-weight: 700;
-  line-height: 0.8;
-
-  @media (min-width: ${BP_MOBILE}) {
-    text-align: right;
-  }
-`
-
 const StyledVideo = styled.figure`
   margin: 0;
   grid-area: video;
@@ -79,7 +49,7 @@ const StyledVideo = styled.figure`
   padding-bottom: 56.35%;
   background: #000;
 
-  @media (max-width: ${BP_DESKTOP}) {
+  @media (max-width: ${BREAKPOINT}) {
     display: none;
   }
 `
@@ -93,10 +63,6 @@ const StyledImage = styled.figure`
   top: 2em;
   bottom: 0;
   margin: 0;
-  width: 100%;
-  height: 0;
-  padding-bottom: 100%;
-  background: #000;
   text-align: center;
 `
 
@@ -110,49 +76,6 @@ const StyledDetails = styled.div`
       display: none;
     }
   }
-`
-
-const StyledActions = styled.nav`
-  grid-area: actions;
-  display: grid;
-  grid-gap: 1em;
-  grid-template-columns: 1fr 1fr;
-  align-self: start;
-  margin: -0.5em 0 0;
-  font-size: 0.75em;
-
-  @media (min-width: ${BP_MOBILE}) {
-    grid-template-columns: 1fr;
-    margin: 0;
-  }
-`
-
-const StyledButton = styled(Button)<{
-  $hideOnDesktop?: boolean
-  $wideOnMobile?: boolean
-}>`
-  ${({ $wideOnMobile }) =>
-    $wideOnMobile &&
-    `
-    @media (max-width: ${BP_MOBILE}) {
-      grid-column: span 2;
-    }
-  `}
-
-  ${({ $hideOnDesktop }) =>
-    $hideOnDesktop &&
-    `
-    @media (min-width: ${BP_DESKTOP}) {
-      display: none !important;
-    }
-  `}
-`
-
-const StyledPreviews = styled.aside`
-  grid-area: previews;
-  /* display: grid;
-  grid-gap: 2em;
-  grid-template-columns: 1fr 1fr; */
 `
 
 const StyledLink = styled.a<{ $internal: boolean }>`
@@ -192,15 +115,12 @@ export const SketchPage = ({
   appLink,
   imagePath,
   markdownDescription,
-  previewSketches,
   pieces,
   datePublished,
   designNoiseSeeds,
   cutNoiseSeeds,
 }: Props) => (
   <StyledGrid>
-    {/* <StyledTitle>{id}</StyledTitle> */}
-
     <StyledVideo>
       <Player id={id} youTubeLink={youTubeLink} imagePath={imagePath} />
     </StyledVideo>
@@ -252,20 +172,6 @@ export const SketchPage = ({
         </p>
       </StyledImage>
     </StyledImageWrapper>
-    {/* 
-    <StyledActions>
-      <Link href={appLink} passHref>
-        <StyledButton $wideOnMobile>Open in explorer</StyledButton>
-      </Link>
-      <StyledButton
-        href={`https://github.com/pouretrebelle/jigsaws/tree/master/sketches/${id}`}
-      >
-        Check out code
-      </StyledButton>
-      <StyledButton $hideOnDesktop href={youTubeLink}>
-        Watch solve
-      </StyledButton>
-    </StyledActions> */}
 
     <StyledDetails>
       <ReactMarkdown
@@ -318,14 +224,5 @@ export const SketchPage = ({
         .
       </p>
     </StyledDetails>
-
-    {/* <StyledPreviews>
-      {previewSketches.map((sketch, i) => (
-        <div key={sketch.id}>
-          Go to {i === 0 ? 'next' : 'previous'} sketch - {sketch.id}
-          <SketchCard key={sketch.id} {...sketch} />
-        </div>
-      ))}
-    </StyledPreviews> */}
   </StyledGrid>
 )

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
+import dayjs from 'dayjs'
+import advancedFormat from 'dayjs/plugin/advancedFormat'
+dayjs.extend(advancedFormat)
 
 import { SketchContent } from 'types'
 import { Button } from 'components/Button'
@@ -195,6 +198,7 @@ interface Props extends SketchContent {
 
 export const SketchPage = ({
   id,
+  datePublished,
   youTubeLink,
   appLink,
   imagePath,
@@ -216,6 +220,7 @@ export const SketchPage = ({
       </Link>
     </>
   )
+  const dayjsDatePublished = dayjs(datePublished)
 
   return (
     <StyledGrid>
@@ -261,7 +266,10 @@ export const SketchPage = ({
           }}
         />
         <StyledMeta>
-          {pieces} pieces &bull; Solved in {timeToSolve}
+          {pieces} pieces &bull; Solved in {timeToSolve} &bull; Published on{' '}
+          <time dateTime={dayjsDatePublished.format('YYYY-MM-DD')}>
+            {dayjsDatePublished.format('Do MMMM ′YY')}
+          </time>
         </StyledMeta>
       </StyledDetails>
 

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -296,6 +296,7 @@ export const SketchPage = ({
         {[...Array(3)].map((_, i) => (
           <SketchPreviewCard
             key={i}
+            id={id}
             designNoiseSeeds={designNoiseSeeds}
             cutNoiseSeeds={cutNoiseSeeds}
           />

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -203,6 +203,7 @@ export const SketchPage = ({
   imagePath,
   markdownDescription,
   pieces,
+  timeToSolve,
   designNoiseSeeds,
   cutNoiseSeeds,
   nextSketchLink,
@@ -257,7 +258,9 @@ export const SketchPage = ({
             link: LinkWrapper,
           }}
         />
-        <StyledMeta>{pieces} pieces &bull; Solved in 1h 43mins</StyledMeta>
+        <StyledMeta>
+          {pieces} pieces &bull; Solved in {timeToSolve}
+        </StyledMeta>
       </StyledDetails>
 
       <StyledPreviews>

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -20,7 +20,7 @@ const StyledGrid = styled.article`
   display: grid;
   grid-template-rows: auto 1fr;
   grid-template-columns: 2fr 3fr;
-  grid-template-areas: 'image preview' 'image details' 'video video';
+  grid-template-areas: 'image details' 'image details' 'video video';
   grid-gap: 2em;
   margin: 3em 0;
 
@@ -273,7 +273,7 @@ export const SketchPage = ({
         </StyledMeta>
       </StyledDetails>
 
-      <StyledPreviews>
+      {/* <StyledPreviews>
         <StyledPreviewGrid>
           {[...Array(3)].map((_, i) => (
             <SketchPreviewCard
@@ -292,7 +292,7 @@ export const SketchPage = ({
         </StyledPreviewDescription>
 
         <StyledDivider />
-      </StyledPreviews>
+      </StyledPreviews> */}
     </StyledGrid>
   )
 }

--- a/src/components/SketchPage/index.tsx
+++ b/src/components/SketchPage/index.tsx
@@ -1,10 +1,13 @@
+import React from 'react'
 import styled, { css } from 'styled-components'
 import Link from 'next/link'
 
 import { SketchContent } from 'types'
+import { makeRandomSeedArray } from 'lib/seeds'
 import { CloudinaryImage } from 'components/CloudinaryImage'
 import { SketchCard } from 'components/SketchCard'
 import { Button } from 'components/Button'
+import RefreshButton from 'components/AppSidebar/Controls/RefreshButton'
 
 import { Player } from './Player'
 import ReactMarkdown from 'react-markdown'
@@ -14,13 +17,13 @@ const BP_DESKTOP = '900px'
 
 const StyledGrid = styled.article`
   display: grid;
-  grid-template-columns: 2fr 2fr 2fr 3fr;
-  grid-template-rows: auto auto auto 1fr;
-  grid-template-areas: 'title title video video' 'image image video video' 'image image details details' 'empty actions details details';
+  grid-template-columns: 1fr 2fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas: 'video video' 'image details';
   grid-gap: 2em;
   margin: 3em 0;
 
-  @media (max-width: ${BP_DESKTOP}) {
+  /* @media (max-width: ${BP_DESKTOP}) {
     grid-template-columns: 1fr 2fr;
     grid-template-rows: auto 1fr;
     grid-template-areas: 'title image' 'actions image' 'empty details';
@@ -32,6 +35,14 @@ const StyledGrid = styled.article`
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto auto;
     grid-template-areas: 'title' 'image' 'actions' 'details' 'previews';
+  } */
+
+  @media (max-width: ${BP_MOBILE}) {
+    margin: 2em 0;
+    grid-gap: 1.5em;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto auto;
+    grid-template-areas: 'image' 'details';
   }
 
   > * > *:first-child {
@@ -75,14 +86,20 @@ const StyledVideo = styled.figure`
   }
 `
 
-const StyledImage = styled.figure`
-  margin: 0;
+const StyledImageWrapper = styled.div`
   grid-area: image;
-  position: relative;
+`
+
+const StyledImage = styled.figure`
+  position: sticky;
+  top: 2em;
+  bottom: 0;
+  margin: 0;
   width: 100%;
   height: 0;
   padding-bottom: 100%;
   background: #000;
+  text-align: center;
 `
 
 const StyledDetails = styled.div`
@@ -134,10 +151,10 @@ const StyledButton = styled(Button)<{
 `
 
 const StyledPreviews = styled.aside`
-  display: grid;
-  grid-gap: 1em;
-  grid-template-columns: repeat(2, 1fr);
-  margin: 2em 0 0;
+  grid-area: previews;
+  /* display: grid;
+  grid-gap: 2em;
+  grid-template-columns: 1fr 1fr; */
 `
 
 const StyledLink = styled.a<{ $internal: boolean }>`
@@ -178,21 +195,67 @@ export const SketchPage = ({
   imagePath,
   markdownDescription,
   previewSketches,
+  pieces,
+  datePublished,
 }: Props) => (
   <StyledGrid>
-    <StyledTitle>{id}</StyledTitle>
+    {/* <StyledTitle>{id}</StyledTitle> */}
 
     <StyledVideo>
       <Player id={id} youTubeLink={youTubeLink} imagePath={imagePath} />
     </StyledVideo>
 
-    <StyledImage>
-      <CloudinaryImage
-        imagePath={imagePath.solveEnd}
-        aspectRatio={1}
-      />
-    </StyledImage>
-
+    <StyledImageWrapper>
+      <StyledImage>
+        <CloudinaryImage imagePath={imagePath.solveEnd} aspectRatio={1} />
+        <p style={{ marginTop: '1em' }}>
+          Posted{' '}
+          {new Date(datePublished).toLocaleDateString('en-GB')}
+        </p>
+        <p>
+          Solved 1h 43mins
+          </p>
+        <p style={{ marginBottom: '0.5em' }}>{pieces} pieces</p>
+        <p>
+          <svg
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 15 15"
+            style={{ width: '1em', height: '1em', marginRight: '0.5em' }}
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M9.97 3.47a.75.75 0 011.06 0l3.75 3.75a.75.75 0 010 1.06l-3.75 3.75a.75.75 0 11-1.06-1.06l2.47-2.47H.75a.75.75 0 010-1.5h11.69L9.97 4.53a.75.75 0 010-1.06z"
+              fill="#000"
+            />
+          </svg>{' '}
+          Previous puzzle
+        </p>
+        <p>
+          <svg
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 15 15"
+            style={{
+              width: '1em',
+              height: '1em',
+              marginRight: '0.5em',
+              transform: 'rotate(180deg)',
+            }}
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M9.97 3.47a.75.75 0 011.06 0l3.75 3.75a.75.75 0 010 1.06l-3.75 3.75a.75.75 0 11-1.06-1.06l2.47-2.47H.75a.75.75 0 010-1.5h11.69L9.97 4.53a.75.75 0 010-1.06z"
+              fill="#000"
+            />
+          </svg>{' '}
+          Next puzzle
+        </p>
+      </StyledImage>
+    </StyledImageWrapper>
+    {/* 
     <StyledActions>
       <Link href={appLink} passHref>
         <StyledButton $wideOnMobile>Open in explorer</StyledButton>
@@ -205,7 +268,7 @@ export const SketchPage = ({
       <StyledButton $hideOnDesktop href={youTubeLink}>
         Watch solve
       </StyledButton>
-    </StyledActions>
+    </StyledActions> */}
 
     <StyledDetails>
       <ReactMarkdown
@@ -217,11 +280,59 @@ export const SketchPage = ({
         }}
       />
 
-      <StyledPreviews>
-        {previewSketches.map((sketch) => (
-          <SketchCard key={sketch.id} {...sketch} />
+      <h2 style={{ fontSize: '1.5em', margin: '1em 0 0' }}>Explore designs</h2>
+      <p>
+        <small>
+          These designs have been generated on the fly from the code for this
+          jigsaw:
+        </small>
+      </p>
+
+      <section
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr',
+          gridGap: '1em',
+          margin: '0.5em 0',
+        }}
+      >
+        {[...Array(3)].map((_, i) => (
+          <article key={i}>
+            <CloudinaryImage
+              imagePath={`0${parseInt(id) - 1 - i}_solve_end.jpg`}
+              aspectRatio={1}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <small>{makeRandomSeedArray(4).join('_')}</small>
+              <RefreshButton />
+            </div>
+          </article>
         ))}
-      </StyledPreviews>
+      </section>
+
+      <p>
+        You can play with the parameters of this programme in{' '}
+        <Link href={appLink} passHref>
+          <a>the explorer</a>
+        </Link>{' '}
+        or check the code out{' '}
+        <Link
+          href={`https://github.com/pouretrebelle/jigsaws/tree/master/sketches/${id}`}
+          passHref
+        >
+          <a>on GitHub</a>
+        </Link>
+        .
+      </p>
     </StyledDetails>
+
+    {/* <StyledPreviews>
+      {previewSketches.map((sketch, i) => (
+        <div key={sketch.id}>
+          Go to {i === 0 ? 'next' : 'previous'} sketch - {sketch.id}
+          <SketchCard key={sketch.id} {...sketch} />
+        </div>
+      ))}
+    </StyledPreviews> */}
   </StyledGrid>
 )

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -20,9 +20,10 @@ const StyledActions = styled.div`
   flex: 0 0 0;
 `
 
-type Props = Pick<SketchContent, 'designNoiseSeeds' | 'cutNoiseSeeds'>
+type Props = Pick<SketchContent, 'id' | 'designNoiseSeeds' | 'cutNoiseSeeds'>
 
 export const SketchPreviewCard: React.FC<Props> = ({
+  id,
   designNoiseSeeds,
   cutNoiseSeeds,
 }) => {
@@ -40,7 +41,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
     <article>
       <ResponsiveImage
         formatPath={({ width }) =>
-          `/api/preview.png?width=${width}&designSeeds=${designSeeds.join(
+          `/api/preview/${id}?width=${width}&designSeeds=${designSeeds.join(
             ','
           )}&cutSeeds=${cutSeeds.join(',')}`
         }

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
 
 import { SketchContent } from 'types'
+import { EnvContext } from 'env'
 import { makeRandomSeed, setLocalStorageSeeds } from 'lib/seeds'
 import { ResponsiveImage } from 'components/ResponsiveImage'
 import { SketchVariant } from 'components/SketchVariant'
@@ -34,6 +35,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
   designNoiseSeeds: sketchDesignNoiseSeeds,
   cutNoiseSeeds: sketchCutNoiseSeeds,
 }) => {
+  const { trackEvent } = useContext(EnvContext)
   const [designNoiseSeeds, setDesignNoiseSeeds] = useState(
     sketchDesignNoiseSeeds.map(makeRandomSeed)
   )
@@ -44,6 +46,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
   const shuffleSeeds = () => {
     setDesignNoiseSeeds(sketchDesignNoiseSeeds.map(makeRandomSeed))
     setCutNoiseSeeds(sketchCutNoiseSeeds.map(makeRandomSeed))
+    trackEvent('Shuffle preview seeds', { id })
   }
 
   return (

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -40,7 +40,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
   }
 
   return (
-    <StyledArticle key={`${id}${designSeeds.join('')}${cutSeeds.join('')}`}>
+    <StyledArticle>
       <ResponsiveImage
         formatPath={({ width }) =>
           `/api/preview/${id}?width=${width}&designSeeds=${designSeeds.join(

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -5,15 +5,17 @@ import { SketchContent } from 'types'
 import { makeRandomSeed } from 'lib/seeds'
 import { ResponsiveImage } from 'components/ResponsiveImage'
 import RefreshButton from 'components/AppSidebar/Controls/RefreshButton'
+import { SketchVariant } from 'components/SketchVariant'
+
+const StyledArticle = styled.article`
+  min-width: 0;
+  font-size: 0.75em;
+`
 
 const StyledMeta = styled.aside`
   display: flex;
   min-width: 0;
-`
-
-const StyledName = styled.div`
-  flex: 1;
-  font-size: 0.75em;
+  gap: 0.5em;
 `
 
 const StyledActions = styled.div`
@@ -38,7 +40,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
   }
 
   return (
-    <article>
+    <StyledArticle key={`${id}${designSeeds.join('')}${cutSeeds.join('')}`}>
       <ResponsiveImage
         formatPath={({ width }) =>
           `/api/preview/${id}?width=${width}&designSeeds=${designSeeds.join(
@@ -48,13 +50,14 @@ export const SketchPreviewCard: React.FC<Props> = ({
         aspectRatio={1}
       />
       <StyledMeta>
-        <StyledName>
-          {designSeeds.join('-')}_{cutSeeds.join('-')}
-        </StyledName>
+        <SketchVariant
+          designNoiseSeeds={designSeeds}
+          cutNoiseSeeds={cutSeeds}
+        />
         <StyledActions>
           <RefreshButton onClick={refreshSeeds} />
         </StyledActions>
       </StyledMeta>
-    </article>
+    </StyledArticle>
   )
 }

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import styled from 'styled-components'
+import Link from 'next/link'
 
 import { SketchContent } from 'types'
-import { makeRandomSeed } from 'lib/seeds'
+import { makeRandomSeed, setLocalStorageSeeds } from 'lib/seeds'
 import { ResponsiveImage } from 'components/ResponsiveImage'
 import { SketchVariant } from 'components/SketchVariant'
 import { ShuffleButton } from 'components/ShuffleButton'
@@ -26,33 +27,46 @@ type Props = Pick<SketchContent, 'id' | 'designNoiseSeeds' | 'cutNoiseSeeds'>
 
 export const SketchPreviewCard: React.FC<Props> = ({
   id,
-  designNoiseSeeds,
-  cutNoiseSeeds,
+  designNoiseSeeds: sketchDesignNoiseSeeds,
+  cutNoiseSeeds: sketchCutNoiseSeeds,
 }) => {
-  const [designSeeds, setDesignSeeds] = useState(
-    designNoiseSeeds.map(makeRandomSeed)
+  const [designNoiseSeeds, setDesignNoiseSeeds] = useState(
+    sketchDesignNoiseSeeds.map(makeRandomSeed)
   )
-  const [cutSeeds, setCutSeeds] = useState(cutNoiseSeeds.map(makeRandomSeed))
+  const [cutNoiseSeeds, setCutNoiseSeeds] = useState(
+    sketchCutNoiseSeeds.map(makeRandomSeed)
+  )
 
   const shuffleSeeds = () => {
-    setDesignSeeds(designNoiseSeeds.map(makeRandomSeed))
-    setCutSeeds(cutNoiseSeeds.map(makeRandomSeed))
+    setDesignNoiseSeeds(sketchDesignNoiseSeeds.map(makeRandomSeed))
+    setCutNoiseSeeds(sketchCutNoiseSeeds.map(makeRandomSeed))
   }
 
   return (
     <StyledArticle>
-      <ResponsiveImage
-        formatPath={({ width }) =>
-          `/api/preview/${id}?width=${width}&designSeeds=${designSeeds.join(
-            ','
-          )}&cutSeeds=${cutSeeds.join(',')}`
-        }
-        aspectRatio={1}
-      />
+      <Link href={`/app/${id}`}>
+        <a
+          onClick={() =>
+            setLocalStorageSeeds({
+              designNoiseSeeds,
+              cutNoiseSeeds,
+            })
+          }
+        >
+          <ResponsiveImage
+            formatPath={({ width }) =>
+              `/api/preview/${id}?width=${width}&designSeeds=${designNoiseSeeds.join(
+                ','
+              )}&cutSeeds=${cutNoiseSeeds.join(',')}`
+            }
+            aspectRatio={1}
+          />
+        </a>
+      </Link>
       <StyledMeta>
         <SketchVariant
-          designNoiseSeeds={designSeeds}
-          cutNoiseSeeds={cutSeeds}
+          designNoiseSeeds={designNoiseSeeds}
+          cutNoiseSeeds={cutNoiseSeeds}
         />
         <StyledActions>
           <ShuffleButton onClick={shuffleSeeds} />

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components'
 import { SketchContent } from 'types'
 import { makeRandomSeed } from 'lib/seeds'
 import { ResponsiveImage } from 'components/ResponsiveImage'
-import RefreshButton from 'components/AppSidebar/Controls/RefreshButton'
 import { SketchVariant } from 'components/SketchVariant'
+import { ShuffleButton } from 'components/ShuffleButton'
 
 const StyledArticle = styled.article`
   min-width: 0;
@@ -34,7 +34,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
   )
   const [cutSeeds, setCutSeeds] = useState(cutNoiseSeeds.map(makeRandomSeed))
 
-  const refreshSeeds = () => {
+  const shuffleSeeds = () => {
     setDesignSeeds(designNoiseSeeds.map(makeRandomSeed))
     setCutSeeds(cutNoiseSeeds.map(makeRandomSeed))
   }
@@ -55,7 +55,7 @@ export const SketchPreviewCard: React.FC<Props> = ({
           cutNoiseSeeds={cutSeeds}
         />
         <StyledActions>
-          <RefreshButton onClick={refreshSeeds} />
+          <ShuffleButton onClick={shuffleSeeds} />
         </StyledActions>
       </StyledMeta>
     </StyledArticle>

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { SketchContent } from 'types'
+import { makeRandomSeed } from 'lib/seeds'
+import { ResponsiveImage } from 'components/ResponsiveImage'
+import RefreshButton from 'components/AppSidebar/Controls/RefreshButton'
+
+const StyledMeta = styled.aside`
+  display: flex;
+  min-width: 0;
+`
+
+const StyledName = styled.div`
+  flex: 1;
+  font-size: 0.75em;
+`
+
+const StyledActions = styled.div`
+  flex: 0 0 0;
+`
+
+type Props = Pick<SketchContent, 'designNoiseSeeds' | 'cutNoiseSeeds'>
+
+export const SketchPreviewCard: React.FC<Props> = ({
+  designNoiseSeeds,
+  cutNoiseSeeds,
+}) => {
+  const [designSeeds, setDesignSeeds] = useState(
+    designNoiseSeeds.map(makeRandomSeed)
+  )
+  const [cutSeeds, setCutSeeds] = useState(cutNoiseSeeds.map(makeRandomSeed))
+
+  const refreshSeeds = () => {
+    setDesignSeeds(designNoiseSeeds.map(makeRandomSeed))
+    setCutSeeds(cutNoiseSeeds.map(makeRandomSeed))
+  }
+
+  return (
+    <article>
+      <ResponsiveImage
+        formatPath={({ width }) =>
+          `/api/preview.png?width=${width}&designSeeds=${designSeeds.join(
+            ','
+          )}&cutSeeds=${cutSeeds.join(',')}`
+        }
+        aspectRatio={1}
+      />
+      <StyledMeta>
+        <StyledName>
+          {designSeeds.join('-')}_{cutSeeds.join('-')}
+        </StyledName>
+        <StyledActions>
+          <RefreshButton onClick={refreshSeeds} />
+        </StyledActions>
+      </StyledMeta>
+    </article>
+  )
+}

--- a/src/components/SketchPreviewCard/index.tsx
+++ b/src/components/SketchPreviewCard/index.tsx
@@ -17,6 +17,10 @@ const StyledMeta = styled.aside`
   display: flex;
   min-width: 0;
   gap: 0.5em;
+
+  > *:first-child {
+    flex: 1;
+  }
 `
 
 const StyledActions = styled.div`

--- a/src/components/SketchVariant/index.tsx
+++ b/src/components/SketchVariant/index.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components'
+import chroma from 'chroma-js'
+
+import { SketchContent } from 'types'
+import { COLOR } from 'styles/tokens'
+
+const StyledSketchVariant = styled.span`
+  position: relative;
+  letter-spacing: -0.1ch;
+  min-width: 0;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 1.5em;
+    width: 2em;
+    background: linear-gradient(
+      to left,
+      ${COLOR.BACKGROUND},
+      ${chroma(COLOR.BACKGROUND).alpha(0.3).hex()},
+      ${chroma(COLOR.BACKGROUND).alpha(0).hex()}
+    );
+    pointer-events: none;
+  }
+`
+
+const StyledInner = styled.span`
+  display: inline-block;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  vertical-align: bottom;
+`
+
+type Props = Pick<SketchContent, 'designNoiseSeeds' | 'cutNoiseSeeds'>
+
+export const SketchVariant = ({ designNoiseSeeds, cutNoiseSeeds }: Props) => {
+  const identifier = `${designNoiseSeeds.join('-')}_${cutNoiseSeeds.join('-')}`
+  return (
+    <StyledSketchVariant title={identifier} aria-hidden>
+      <StyledInner>&#9913;{identifier}</StyledInner>
+    </StyledSketchVariant>
+  )
+}

--- a/src/components/SketchVariant/index.tsx
+++ b/src/components/SketchVariant/index.tsx
@@ -35,13 +35,30 @@ const StyledInner = styled.span`
   vertical-align: bottom;
 `
 
+const StyledIcon = styled.svg`
+  width: 0.6em;
+  height: 0.6em;
+  stroke: currentColor;
+  fill: transparent;
+  vertical-align: unset;
+  margin-right: 0.2em;
+`
+
 type Props = Pick<SketchContent, 'designNoiseSeeds' | 'cutNoiseSeeds'>
 
 export const SketchVariant = ({ designNoiseSeeds, cutNoiseSeeds }: Props) => {
   const identifier = `${designNoiseSeeds.join('-')}_${cutNoiseSeeds.join('-')}`
   return (
     <StyledSketchVariant title={identifier} aria-hidden>
-      <StyledInner>&#9913;{identifier}</StyledInner>
+      <StyledInner>
+        <StyledIcon xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7 7">
+          <path
+            d="M.5 3.50012h6M2 .901978L5 6.09813M2 6.09814L5 .901992"
+            strokeLinecap="round"
+          />
+        </StyledIcon>
+        {identifier}
+      </StyledInner>
     </StyledSketchVariant>
   )
 }

--- a/src/lib/data/getSketchContent.ts
+++ b/src/lib/data/getSketchContent.ts
@@ -1,8 +1,10 @@
 import fs from 'fs'
 import matter from 'gray-matter'
-import { getExcerpt, wrapSketchLinks } from 'lib/markdown/processMarkdown'
 import chroma from 'chroma-js'
+
 import { SketchContent } from 'types'
+import { getExcerpt, wrapSketchLinks } from 'lib/markdown/processMarkdown'
+import { formatDuration } from 'lib/formatting'
 import { COLOR } from 'styles/tokens'
 
 const getRgb = (color: string): string => chroma(color).rgb().join(', ')
@@ -10,7 +12,7 @@ const getRgb = (color: string): string => chroma(color).rgb().join(', ')
 export const getSketchContent = (sketchId: string): SketchContent | null => {
   try {
     const file = fs.readFileSync(`sketches/${sketchId}/README.md`, 'utf8');
-    const { content, data: { datePublished, youTubeLink, pieces, accentColor = COLOR.ACCENT, designNoiseSeeds, cutNoiseSeeds, } } = matter(file)
+    const { content, data: { datePublished, youTubeLink, pieces, timeToSolve, accentColor = COLOR.ACCENT, designNoiseSeeds, cutNoiseSeeds, } } = matter(file)
     const canvas = `${sketchId}_${designNoiseSeeds.join('-')}_${cutNoiseSeeds.join('-')}.png`
 
     return {
@@ -21,6 +23,7 @@ export const getSketchContent = (sketchId: string): SketchContent | null => {
       accentColorRgb: getRgb(accentColor),
       datePublished: +datePublished,
       pieces,
+      timeToSolve: formatDuration(timeToSolve || 3600),
       designNoiseSeeds,
       cutNoiseSeeds,
       youTubeLink: youTubeLink || '',

--- a/src/lib/draw.ts
+++ b/src/lib/draw.ts
@@ -8,6 +8,13 @@ interface DrawArgs {
   state: State
 }
 
+const createCanvas = (width: number, height: number) => {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  return canvas
+}
+
 export const drawBackground = ({ canvas, c, state }: DrawArgs) => {
   if (!state.sketch) return
 
@@ -30,6 +37,7 @@ export const drawDesign = ({ c, state }: Pick<DrawArgs, 'c' | 'state'>) => {
 
   state.sketch.design({
     c,
+    createCanvas,
     simplex,
     seed: state.designNoiseSeeds,
     noiseStart: state.noiseStart,

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,0 +1,9 @@
+export const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds - (hours * 3600)) / 60)
+
+  const minuteString = `${minutes}min${minutes > 1 ? 's' : ''}`
+
+  if (!hours) return minuteString
+  return `${hours}h ${minuteString}`
+}

--- a/src/lib/hooks/useSetLocalStorageSeeds.ts
+++ b/src/lib/hooks/useSetLocalStorageSeeds.ts
@@ -1,12 +1,10 @@
-import { useEffect } from "react"
-import { SketchContent } from "types"
+import { useEffect } from 'react'
+import { SketchContent } from 'types'
+
+import { setLocalStorageSeeds } from 'lib/seeds'
 
 export const useSetLocalStorageSeeds = (sketch: SketchContent) => {
   useEffect(() => {
-    localStorage.setItem('cutNoiseSeeds', JSON.stringify(sketch.cutNoiseSeeds))
-    localStorage.setItem(
-      'designNoiseSeeds',
-      JSON.stringify(sketch.designNoiseSeeds)
-    )
+    setLocalStorageSeeds(sketch)
   }, [sketch.id])
 }

--- a/src/lib/seeds.ts
+++ b/src/lib/seeds.ts
@@ -1,3 +1,5 @@
+import { SketchContent } from 'types'
+
 export const makeRandomSeed = (): string =>
   Math.random()
     .toString(36)
@@ -6,3 +8,11 @@ export const makeRandomSeed = (): string =>
 
 export const makeRandomSeedArray = (length: number): string[] =>
   Array.from({ length }, makeRandomSeed)
+
+export const setLocalStorageSeeds = (sketch: Pick<SketchContent, 'cutNoiseSeeds' | 'designNoiseSeeds'>) => {
+  localStorage.setItem('cutNoiseSeeds', JSON.stringify(sketch.cutNoiseSeeds))
+  localStorage.setItem(
+    'designNoiseSeeds',
+    JSON.stringify(sketch.designNoiseSeeds)
+  )
+}

--- a/src/pages/[sketch].tsx
+++ b/src/pages/[sketch].tsx
@@ -30,7 +30,7 @@ const SketchPage = ({ sketch, previewSketches }: Props) => {
   useSetLocalStorageSeeds(sketch)
 
   return (
-    <PageWrapper accentColorRgb={sketch.accentColorRgb}>
+    <PageWrapper accentColorRgb={sketch.accentColorRgb} title={`Abstract Puzzle ${sketch.id}`}>
       <SEO
         title={sketch.id}
         description={sketch.excerpt}

--- a/src/pages/[sketch].tsx
+++ b/src/pages/[sketch].tsx
@@ -9,35 +9,28 @@ import { SketchPage as SketchPageComponent } from 'components/SketchPage'
 
 const NOW = new Date()
 
-const getSurroundingIds = (id: string, ids: string[]): string[] => {
-  const idIndex = ids.indexOf(id)
-
-  if (idIndex < 0 || ids.length <= 5) return []
-
-  if (idIndex === 0) return ids.slice(1, 3)
-  if (idIndex === ids.length - 1) return ids.slice(-3, -1)
-
-  return [ids[idIndex - 1], ids[idIndex + 1]]
-}
-
 interface Props {
   sketch: SketchContent
-  previewSketches: SketchContent[]
+  olderSketchId?: string
+  newerSketchId?: string
 }
 
-const SketchPage = ({ sketch, previewSketches }: Props) => {
+const SketchPage = ({ sketch, ...props }: Props) => {
   // Set storage to sketch's seeds so the app opens with these values
   useSetLocalStorageSeeds(sketch)
 
   return (
-    <PageWrapper accentColorRgb={sketch.accentColorRgb} title={`Abstract Puzzle ${sketch.id}`}>
+    <PageWrapper
+      accentColorRgb={sketch.accentColorRgb}
+      title={`Abstract Puzzle ${sketch.id}`}
+    >
       <SEO
         title={sketch.id}
         description={sketch.excerpt}
         imagePath={sketch.imagePath.solveEnd}
         smallImage
       />
-      <SketchPageComponent {...sketch} previewSketches={previewSketches} />
+      <SketchPageComponent {...sketch} {...props} />
     </PageWrapper>
   )
 }
@@ -58,17 +51,20 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const sketchId = (params && params.sketch) as string
   const sketches = getAllSketchContent()
-  const sketch = sketches.find(({ id }) => id === sketchId)
+  const sketchIndex = sketches.findIndex(({ id }) => id === sketchId)
+  const sketch = sketches[sketchIndex]
 
-  const previewSketches = getSurroundingIds(
-    sketchId,
-    sketches.map(({ id }) => id)
-  ).map((thisId) => sketches.find(({ id }) => id === thisId))
+  let prevSketchLink = null, nextSketchLink = null
+  if (sketchIndex !== sketches.length - 1)
+    prevSketchLink = sketches[sketchIndex + 1].pageLink
+  if (sketchIndex > 0)
+    nextSketchLink = sketches[sketchIndex - 1].pageLink
 
   return {
     props: {
       sketch,
-      previewSketches,
+      prevSketchLink,
+      nextSketchLink,
     },
   }
 }

--- a/src/pages/api/preview.png.ts
+++ b/src/pages/api/preview.png.ts
@@ -1,0 +1,85 @@
+import SimplexNoise from 'simplex-noise'
+import { createCanvas } from 'canvas'
+
+import { Design, Cut } from 'types'
+import { makeRandomSeed } from 'lib/seeds'
+
+import { settings, design, DesignNoiseSeeds, cut, CutNoiseSeeds } from '../../../sketches/004'
+
+interface Req {
+  query: {
+    width?: string,
+    designSeeds?: string,
+    cutSeeds?: string,
+  }
+}
+
+type Res = NodeJS.WritableStream & {
+  setHeader: (arg0: string, arg1: string) => void;
+  status: (arg0: number) => Res
+  send: (arg0: string) => void
+  pipe: (arg0: any) => void
+}
+
+const handler = (req: Req, res: Res) => {
+  res.setHeader('content-type', 'image/png')
+
+  const canvasWidth = req.query.width ? parseInt(req.query.width) : 200
+  const designSeeds = req.query.designSeeds ? req.query.designSeeds.split(',') : []
+  const cutSeeds = req.query.cutSeeds ? req.query.cutSeeds.split(',') : []
+
+  const canvas = createCanvas(canvasWidth, canvasWidth)
+  const c = canvas.getContext('2d') as CanvasRenderingContext2D
+  const canvasBleed = canvasWidth * 0.1
+
+  const designWidth = canvasWidth - canvasBleed * 2
+  const designCanvas = createCanvas(designWidth, designWidth)
+  const designC = designCanvas.getContext('2d') as CanvasRenderingContext2D
+  const designSimplex = Object.keys(DesignNoiseSeeds).map((_, i) => new SimplexNoise(designSeeds[i] || makeRandomSeed()))
+
+  const designScale = designWidth / (settings.width)
+
+  designC.save()
+  designC.translate(-settings.bleed, -settings.bleed)
+  designC.scale(designScale, designScale)
+
+  if (settings.backgroundColor) {
+    c.fillStyle = settings.backgroundColor
+    c.fillRect(0, 0, designWidth, designWidth)
+  }
+
+  design({
+    c: designC,
+    simplex: designSimplex,
+    noiseStart: 0,
+    ...settings,
+    width: settings.width ? settings.width + settings.bleed * 2 : undefined,
+    height: settings.height ? settings.height + settings.bleed * 2 : undefined,
+  } as Design)
+  designC.restore()
+
+  const cutSimplex = Object.keys(CutNoiseSeeds).map((_, i) => new SimplexNoise(cutSeeds[i] || makeRandomSeed()))
+
+  designC.strokeStyle = 'black'
+  designC.lineWidth = 0.5 / designScale
+
+  designC.save()
+  designC.scale(designScale, designScale)
+  cut({
+    c: designC,
+    simplex: cutSimplex,
+    noiseStart: 0,
+    ...settings
+  } as Cut)
+  designC.restore()
+
+
+  c.fillStyle = '#111'
+  c.fillRect(0, 0, canvasWidth, canvasWidth)
+  c.translate(canvasBleed, canvasBleed)
+  c.drawImage(designCanvas as unknown as CanvasImageSource, 0, 0)
+
+  canvas.createPNGStream().pipe(res)
+}
+
+export default handler

--- a/src/pages/api/preview/[sketch].ts
+++ b/src/pages/api/preview/[sketch].ts
@@ -26,8 +26,8 @@ const handler = async (req: Req, res: Res) => {
   const { settings, design, DesignNoiseSeeds, cut, CutNoiseSeeds } = await import(`../../../../sketches/${req.query.sketch || '001'}/index.ts`)
 
   const canvasWidth = req.query.width ? parseInt(req.query.width) : 200
-  const designSeeds = req.query.designSeeds ? req.query.designSeeds.split(',') : []
-  const cutSeeds = req.query.cutSeeds ? req.query.cutSeeds.split(',') : []
+  const queryDesignSeeds = req.query.designSeeds ? req.query.designSeeds.split(',') : []
+  const queryCutSeeds = req.query.cutSeeds ? req.query.cutSeeds.split(',') : []
 
   const canvas = createCanvas(canvasWidth, canvasWidth)
   const c = canvas.getContext('2d') as CanvasRenderingContext2D
@@ -36,7 +36,7 @@ const handler = async (req: Req, res: Res) => {
   const designWidth = canvasWidth - canvasBleed * 2
   const designCanvas = createCanvas(designWidth, designWidth)
   const designC = designCanvas.getContext('2d') as CanvasRenderingContext2D
-  const designSimplex = Object.keys(DesignNoiseSeeds).map((_, i) => new SimplexNoise(designSeeds[i] || makeRandomSeed()))
+  const designSeeds = Object.keys(DesignNoiseSeeds).map((_, i) => queryDesignSeeds[i] || makeRandomSeed())
 
   const designScale = designWidth / (settings.width)
 
@@ -51,7 +51,8 @@ const handler = async (req: Req, res: Res) => {
 
   design({
     c: designC,
-    simplex: designSimplex,
+    seed: designSeeds,
+    simplex: designSeeds.map(seed => new SimplexNoise(seed)),
     noiseStart: 0,
     ...settings,
     width: settings.width ? settings.width + settings.bleed * 2 : undefined,
@@ -59,7 +60,7 @@ const handler = async (req: Req, res: Res) => {
   } as Design)
   designC.restore()
 
-  const cutSimplex = Object.keys(CutNoiseSeeds).map((_, i) => new SimplexNoise(cutSeeds[i] || makeRandomSeed()))
+  const cutSeeds = Object.keys(CutNoiseSeeds).map((_, i) => queryCutSeeds[i] || makeRandomSeed())
 
   designC.strokeStyle = 'black'
   designC.lineWidth = 0.5 / designScale
@@ -68,7 +69,8 @@ const handler = async (req: Req, res: Res) => {
   designC.scale(designScale, designScale)
   cut({
     c: designC,
-    simplex: cutSimplex,
+    seed: cutSeeds,
+    simplex: cutSeeds.map(seed => new SimplexNoise(seed)),
     noiseStart: 0,
     ...settings
   } as Cut)

--- a/src/pages/api/preview/[sketch].ts
+++ b/src/pages/api/preview/[sketch].ts
@@ -4,10 +4,9 @@ import { createCanvas } from 'canvas'
 import { Design, Cut } from 'types'
 import { makeRandomSeed } from 'lib/seeds'
 
-import { settings, design, DesignNoiseSeeds, cut, CutNoiseSeeds } from '../../../sketches/004'
-
 interface Req {
   query: {
+    sketch?: string,
     width?: string,
     designSeeds?: string,
     cutSeeds?: string,
@@ -21,8 +20,10 @@ type Res = NodeJS.WritableStream & {
   pipe: (arg0: any) => void
 }
 
-const handler = (req: Req, res: Res) => {
+const handler = async (req: Req, res: Res) => {
   res.setHeader('content-type', 'image/png')
+
+  const { settings, design, DesignNoiseSeeds, cut, CutNoiseSeeds } = await import(`../../../../sketches/${req.query.sketch || '001'}/index.ts`)
 
   const canvasWidth = req.query.width ? parseInt(req.query.width) : 200
   const designSeeds = req.query.designSeeds ? req.query.designSeeds.split(',') : []

--- a/src/pages/api/preview/[sketch].ts
+++ b/src/pages/api/preview/[sketch].ts
@@ -41,8 +41,8 @@ const handler = async (req: Req, res: Res) => {
   const designScale = designWidth / (settings.width)
 
   designC.save()
-  designC.translate(-settings.bleed, -settings.bleed)
   designC.scale(designScale, designScale)
+  designC.translate(-settings.bleed, -settings.bleed)
 
   if (settings.backgroundColor) {
     c.fillStyle = settings.backgroundColor

--- a/src/pages/api/preview/[sketch].ts
+++ b/src/pages/api/preview/[sketch].ts
@@ -51,6 +51,7 @@ const handler = async (req: Req, res: Res) => {
 
   design({
     c: designC,
+    createCanvas,
     seed: designSeeds,
     simplex: designSeeds.map(seed => new SimplexNoise(seed)),
     noiseStart: 0,

--- a/src/pages/api/preview/[sketch].ts
+++ b/src/pages/api/preview/[sketch].ts
@@ -23,7 +23,7 @@ type Res = NodeJS.WritableStream & {
 const handler = async (req: Req, res: Res) => {
   res.setHeader('content-type', 'image/png')
 
-  const { settings, design, DesignNoiseSeeds, cut, CutNoiseSeeds } = await import(`../../../../sketches/${req.query.sketch || '001'}/index.ts`)
+  const { settings, design, DesignNoiseSeeds, cut, CutNoiseSeeds } = await import(`.temp/sketches/${req.query.sketch || '001'}/index.ts`)
 
   const canvasWidth = req.query.width ? parseInt(req.query.width) : 200
   const queryDesignSeeds = req.query.designSeeds ? req.query.designSeeds.split(',') : []

--- a/src/pages/archive.tsx
+++ b/src/pages/archive.tsx
@@ -14,7 +14,7 @@ const StyledGrid = styled.section`
   margin: 2em 0;
 
   @media (min-width: 500px) {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 `
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,11 +49,11 @@ const HomePage = ({ latestSketch }: Props) => {
       </StyledDescription>
 
       <StyledButtonWrapper>
-        <Link href={latestSketch.appLink} passHref>
-          <Button>Open explorer</Button>
-        </Link>
         <Link href={latestSketch.pageLink} passHref>
           <Button>Go to latest sketch</Button>
+        </Link>
+        <Link href={latestSketch.appLink} passHref>
+          <Button>Open explorer</Button>
         </Link>
         <FollowButton />
       </StyledButtonWrapper>

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,6 @@ export interface Sketch {
 export interface Cut {
   c: CanvasRenderingContext2D
   simplex: SimplexNoise[]
-  seed: string[]
   width: number
   height: number
   rows: number
@@ -100,7 +99,6 @@ export interface Cut {
 export interface Design {
   c: CanvasRenderingContext2D
   simplex: SimplexNoise[]
-  seed: string[]
   width: number
   height: number
   bleed: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export interface SketchContent {
   accentColorRgb?: string
   datePublished: number
   pieces: number
+  timeToSolve: string
   imagePath: {
     solveStart: string
     solveMiddle: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export interface Cut {
 
 export interface Design {
   c: CanvasRenderingContext2D
+  createCanvas: (width: number, height: number) => HTMLCanvasElement | OffscreenCanvas
   simplex: SimplexNoise[]
   seed: string[]
   width: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface Sketch {
 export interface Cut {
   c: CanvasRenderingContext2D
   simplex: SimplexNoise[]
+  seed: string[]
   width: number
   height: number
   rows: number
@@ -99,6 +100,7 @@ export interface Cut {
 export interface Design {
   c: CanvasRenderingContext2D
   simplex: SimplexNoise[]
+  seed: string[]
   width: number
   height: number
   bleed: number

--- a/utils/colorUtils.ts
+++ b/utils/colorUtils.ts
@@ -5,7 +5,7 @@ export const hsl = (h: number, s: number, l: number): string =>
   `hsl(${h}, ${clamp(s, 0, 100)}%, ${clamp(l, 0, 100)}%)`
 
 export const hsla = (h: number, s: number, l: number, a: number): string =>
-  `hsl(${h}, ${clamp(s, 0, 100)}%, ${clamp(l, 0, 100)}%, ${clamp(a, 0, 1)})`
+  `hsla(${h}, ${clamp(s, 0, 100)}%, ${clamp(l, 0, 100)}%, ${clamp(a, 0, 1)})`
 
 export const rotateHue = (
   color: string | chroma.Color,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "pages/api/preview/[sketch].ts": {
+      "includeFiles": "sketches/**"
+    }
+  }
+}


### PR DESCRIPTION
Blockers for merge:

- [ ] ~~https://github.com/vercel/next.js/issues/8251~~
  Workarounds https://github.com/pouretrebelle/jigsaws/pull/39/commits/b0ab7b16a7325d5cd4e66cfb12a632b68ab88611  https://github.com/pouretrebelle/jigsaws/pull/39/commits/aa7de56ff378931cca2f97e7d7ff7d42e491a698 https://github.com/pouretrebelle/jigsaws/pull/39/commits/f717eba403d217620ac282380694d050b171be02
- [x] https://github.com/Automattic/node-canvas/pull/1769, will be released in 2.8.0
- [ ] Fixes for zlib v1.2.9
- [ ] Something for long-load sketches
- [ ] Previews on mobile

---

- New sketch page layout
- Live sketch lambda-rendered previews
- Adding pieces + solve meta
- Update archive page layout

---

![image](https://user-images.githubusercontent.com/1901935/116982793-2ab36e80-acc1-11eb-8c60-3f366a0c7153.png)

