### PR TITLE
:bug: Fix previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint . --ext .ts,.tsx",
     "type-check": "tsc --noEmit",
-    "vercel-build": "mkdir -p src/.temp/sketches && npm run sync:sketches && npm run build",
+    "vercel-build": "yum install libuuid-devel libmount-devel zlib-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && mkdir -p src/.temp/sketches && npm run sync:sketches && npm run build",
     "sync:sketches": "cp -r sketches src/.temp/",
     "prepare": "husky install"
   },


### PR DESCRIPTION
# Tried

1. with `LD_LIBRARY_PATH=/var/task/node_modules/canvas/build/Release`
    This had been the solution since #58 and just decided to stop working
    
	Old error that was solved in #58 was
	```json
	{"errorType":"Error","errorMessage":"/lib64/libz.so.1: version `ZLIB_1.2.9' not found (required by /var/task/node_modules/canvas/build/Release/libpng16.so.16)","stack":["Error: /lib64/libz.so.1: version `ZLIB_1.2.9' not found (required by /var/task/node_modules/canvas/build/Release/libpng16.so.16)","```

1. with `LD_LIBRARY_PATH=/var/task/node_modules/canvas/build/Release` and [`next.config.js` additions](https://github.com/Automattic/node-canvas/issues/1779#issuecomment-895885846)
    `{"errorType":"Error","errorMessage":"libuuid.so.1: cannot open shared object file: No such file or directory","stack":["Error: libuuid.so.1: cannot open shared object file: No such file or directory","`
1. just `next.config.js` additions
    `{"errorType":"Error","errorMessage":"libuuid.so.1: cannot open shared object file: No such file or directory","stack":["Error: libuuid.so.1: cannot open shared object file: No such file or directory","`
1. with `LD_LIBRARY_PATH=/vercel/path0/node_modules/canvas/build/Release` and `next.config.js` additions
    `{"errorType":"Error","errorMessage":"libuuid.so.1: cannot open shared object file: No such file or directory","stack":["Error: libuuid.so.1: cannot open shared object file: No such file or directory","`
1. with nothing
    `{"errorType":"Error","errorMessage":"libuuid.so.1: cannot open shared object file: No such file or directory","stack":["Error: libuuid.so.1: cannot open shared object file: No such file or directory","`
1. add `yum install libuuid` to `vercel-build`
    result was:    
    ```
    19:35:21.079 | > yum install libuuid && mkdir -p src/.temp/sketches && npm run sync:sketches && npm run build
    19:35:23.609 | Package libuuid-2.30.2-2.amzn2.0.4.x86_64 already installed and latest version
    ```
    and same error
1. add `yum install libuuid-devel libmount-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ ` to `vercel-build` (rec'd [here](https://github.com/Automattic/node-canvas/issues/1448#issuecomment-698757961), curiously I had it in this repo then removed it in b6807756a5a938ff849954651c706701cc5762ce) because everything worked fine with just solution 1) 🎉 
